### PR TITLE
Add `GET /api/articles/:article_id` endpoint and corresponding tests

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -58,11 +58,11 @@ describe("GET /api/topics", () => {
 describe("GET /api/articles/:article_id", () => {
     test("200: returns article with the given id", () => {
         const expected = {
-            article_id: 1,
-            title: "Living in the shadow of a great man",
-            topic: "mitch",
             author: "butter_bridge",
+            title: "Living in the shadow of a great man",
+            article_id: 1,
             body: "I find this existence challenging",
+            topic: "mitch",
             created_at: 1594329060000,
             votes: 100,
             article_img_url:
@@ -87,7 +87,7 @@ describe("GET /api/articles/:article_id", () => {
             });
     });
 
-    test("400: returns error when given invalid id", () => {
+    test("400: returns error when given invalid id type", () => {
         return request(app)
             .get("/api/articles/one")
             .expect(400)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -63,7 +63,7 @@ describe("GET /api/articles/:article_id", () => {
             article_id: 1,
             body: "I find this existence challenging",
             topic: "mitch",
-            created_at: 1594329060000,
+            created_at: "2020-07-09T21:11:00.000Z",
             votes: 100,
             article_img_url:
                 "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -26,6 +26,17 @@ describe("GET /api/does-not-exist", () => {
     });
 });
 
+describe("GET /api", () => {
+    test("200: returns the object in endpoints.json", () => {
+        return request(app)
+            .get("/api")
+            .expect(200)
+            .then(({ body: {endpoints} }) => {
+                expect(endpoints).toEqual(endpointsData);
+            });
+    });
+});
+
 describe("GET /api/topics", () => {
     test("200: returns all topics as objects with correct attributes", () => {
         return request(app)
@@ -40,17 +51,6 @@ describe("GET /api/topics", () => {
                         slug: expect.any(String),
                     });
                 });
-            });
-    });
-});
-
-describe("GET /api", () => {
-    test("200: returns the object in endpoints.json", () => {
-        return request(app)
-            .get("/api")
-            .expect(200)
-            .then(({ body: {endpoints} }) => {
-                expect(endpoints).toEqual(endpointsData);
             });
     });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -31,7 +31,7 @@ describe("GET /api", () => {
         return request(app)
             .get("/api")
             .expect(200)
-            .then(({ body: {endpoints} }) => {
+            .then(({ body: { endpoints } }) => {
                 expect(endpoints).toEqual(endpointsData);
             });
     });
@@ -51,6 +51,49 @@ describe("GET /api/topics", () => {
                         slug: expect.any(String),
                     });
                 });
+            });
+    });
+});
+
+describe("GET /api/articles/:article_id", () => {
+    test("200: returns article with the given id", () => {
+        const expected = {
+            article_id: 1,
+            title: "Living in the shadow of a great man",
+            topic: "mitch",
+            author: "butter_bridge",
+            body: "I find this existence challenging",
+            created_at: 1594329060000,
+            votes: 100,
+            article_img_url:
+                "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        };
+
+        return request(app)
+            .get("/api/articles/1")
+            .expect(200)
+            .then(({ body: { article } }) => {
+                expect(article).toEqual(expected);
+            });
+    });
+
+    test("404: returns error when given id without article", () => {
+        return request(app)
+            .get("/api/articles/1000")
+            .expect(404)
+            .then(({ body: { msg, desc } }) => {
+                expect(msg).toBe("Not found");
+                expect(desc).toBe("No article found with given ID");
+            });
+    });
+
+    test("400: returns error when given invalid id", () => {
+        return request(app)
+            .get("/api/articles/one")
+            .expect(400)
+            .then(({ body: { msg, desc } }) => {
+                expect(msg).toBe("Bad request");
+                expect(desc).toBe("ID of invalid type given");
             });
     });
 });

--- a/app.js
+++ b/app.js
@@ -2,12 +2,15 @@ const express = require("express");
 const { getTopics } = require("./controllers/topics.controllers");
 const { getNotExists } = require("./controllers/errors.controllers");
 const { getEndpoints } = require("./controllers/api.controllers");
+const { getArticleById } = require("./controllers/articles.controllers");
 
 const app = express();
 
 app.get("/api", getEndpoints);
 
 app.get("/api/topics", getTopics);
+
+app.get("/api/articles/:article_id", getArticleById)
 
 // Allows error from invalid endpoint to go into middleware
 app.get("/*", getNotExists);
@@ -19,5 +22,13 @@ app.use((err, req, res, next) => {
 
     next(err);
 });
+
+app.use((err, req, res, next) => {
+    if (err.code === "22P02") {
+        res.status(400).send({msg: "Bad request", desc: "ID of invalid type given"})
+    }
+
+    next(err)
+})
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const { getTopics } = require("./controllers/topics.controllers");
-const { handleBadEndpoint } = require("./controllers/errors.controllers");
+const { handleBadEndpoint, handleBadIdType, handleCustomError } = require("./controllers/errors.controllers");
 const { getEndpoints } = require("./controllers/api.controllers");
 const { getArticleById } = require("./controllers/articles.controllers");
 
@@ -14,20 +14,8 @@ app.get("/api/articles/:article_id", getArticleById)
 
 app.all("/*", handleBadEndpoint);
 
-app.use((err, req, res, next) => {
-    if (err.status && err.msg && err.desc) {
-        res.status(err.status).send({ msg: err.msg, desc: err.desc });
-    }
+app.use(handleCustomError);
 
-    next(err);
-});
-
-app.use((err, req, res, next) => {
-    if (err.code === "22P02") {
-        res.status(400).send({msg: "Bad request", desc: "ID of invalid type given"})
-    }
-
-    next(err)
-})
+app.use(handleBadIdType)
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const { getTopics } = require("./controllers/topics.controllers");
-const { getNotExists } = require("./controllers/errors.controllers");
+const { handleBadEndpoint } = require("./controllers/errors.controllers");
 const { getEndpoints } = require("./controllers/api.controllers");
 const { getArticleById } = require("./controllers/articles.controllers");
 
@@ -12,8 +12,7 @@ app.get("/api/topics", getTopics);
 
 app.get("/api/articles/:article_id", getArticleById)
 
-// Allows error from invalid endpoint to go into middleware
-app.get("/*", getNotExists);
+app.all("/*", handleBadEndpoint);
 
 app.use((err, req, res, next) => {
     if (err.status && err.msg && err.desc) {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,0 +1,11 @@
+const { selectArticleById } = require("../models/articles.models");
+
+exports.getArticleById = (req, res, next) => {
+    const article_id = req.params.article_id;
+
+    selectArticleById(article_id)
+        .then((article) => {
+            res.status(200).send({ article });
+        })
+        .catch(next);
+};

--- a/controllers/errors.controllers.js
+++ b/controllers/errors.controllers.js
@@ -1,3 +1,3 @@
-exports.getNotExists = (req, res, next) => {
+exports.handleBadEndpoint = (req, res, next) => {
     next({ status: 404, msg: "Not found", desc: "Endpoint does not exist" });
 };

--- a/controllers/errors.controllers.js
+++ b/controllers/errors.controllers.js
@@ -1,3 +1,22 @@
 exports.handleBadEndpoint = (req, res, next) => {
     next({ status: 404, msg: "Not found", desc: "Endpoint does not exist" });
 };
+
+exports.handleCustomError = (err, req, res, next) => {
+    if (err.status && err.msg && err.desc) {
+        res.status(err.status).send({ msg: err.msg, desc: err.desc });
+    }
+
+    next(err);
+};
+
+exports.handleBadIdType = (err, req, res, next) => {
+    if (err.code === "22P02") {
+        res.status(400).send({
+            msg: "Bad request",
+            desc: "ID of invalid type given",
+        });
+    }
+
+    next(err);
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -1,29 +1,43 @@
 {
-  "GET /api": {
-    "description": "serves up a json representation of all the available endpoints of the api"
-  },
-  "GET /api/topics": {
-    "description": "serves an array of all topics",
-    "queries": [],
-    "exampleResponse": {
-      "topics": [{ "slug": "football", "description": "Footie!" }]
-    }
-  },
-  "GET /api/articles": {
-    "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
-    "exampleResponse": {
-      "articles": [
-        {
-          "title": "Seafood substitutions are increasing",
-          "topic": "cooking",
-          "author": "weegembump",
-          "body": "Text from the article..",
-          "created_at": "2018-05-30T15:59:13.341Z",
-          "votes": 0,
-          "comment_count": 6
+    "GET /api": {
+        "description": "serves up a json representation of all the available endpoints of the api"
+    },
+    "GET /api/topics": {
+        "description": "serves an array of all topics",
+        "queries": [],
+        "exampleResponse": {
+            "topics": [{ "slug": "football", "description": "Footie!" }]
         }
-      ]
+    },
+    "GET /api/articles": {
+        "description": "serves an array of all articles",
+        "queries": ["author", "topic", "sort_by", "order"],
+        "exampleResponse": {
+            "articles": [
+                {
+                    "title": "Seafood substitutions are increasing",
+                    "topic": "cooking",
+                    "author": "weegembump",
+                    "body": "Text from the article..",
+                    "created_at": "2018-05-30T15:59:13.341Z",
+                    "votes": 0,
+                    "comment_count": 6
+                }
+            ]
+        }
+    },
+    "GET /api/articles/:article_id": {
+        "description": "serves a single articles with given article_id",
+        "exampleResponse": {
+            "article": {
+                "title": "Living in the shadow of a great man",
+                "topic": "mitch",
+                "author": "butter_bridge",
+                "body": "I find this existence challenging",
+                "created_at": "2020-07-09T21:11:00.000Z",
+                "votes": 100,
+                "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+            }
+        }
     }
-  }
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -17,7 +17,8 @@ exports.selectArticleById = (article_id) => {
             // For some reason, Postgres seems to be returning the date with a
             // timezone I didn't ask for, so I need to account for the discrepency
             const offsetMilliseconds = article.created_at.getTimezoneOffset() * 60 * 1000;
-            article.created_at = Date.parse(article.created_at) - offsetMilliseconds;
+            const correctTimestamp = Date.parse(article.created_at) - offsetMilliseconds;
+            article.created_at = new Date(correctTimestamp);
             return article;
         });
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,0 +1,23 @@
+const db = require("../db/connection");
+
+exports.selectArticleById = (article_id) => {
+    return db
+        .query("SELECT * FROM articles WHERE article_id = $1", [article_id])
+        .then(({ rows }) => {
+            if (rows.length === 0) {
+                return Promise.reject({
+                    status: 404,
+                    msg: "Not found",
+                    desc: "No article found with given ID",
+                });
+            }
+            
+            const article = rows[0];
+
+            // For some reason, Postgres seems to be returning the date with a
+            // timezone I didn't ask for, so I need to account for the discrepency
+            const offsetMilliseconds = article.created_at.getTimezoneOffset() * 60 * 1000;
+            article.created_at = Date.parse(article.created_at) - offsetMilliseconds;
+            return article;
+        });
+};


### PR DESCRIPTION
For some reason, Postgres returns the date of the article with the UTC-1 timezone on my machine. I do not know if this behavior is consistent between systems and time zones. I could not figure out how to stop it from happening locally, so for now I'm correcting the timestamp post-retrieval.

I don't understand anything about this.