### PR TITLE
Fix incorrect dates being returned from node-postgres

### DIFF
--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -42,7 +42,7 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
         topic VARCHAR NOT NULL REFERENCES topics(slug),
         author VARCHAR NOT NULL REFERENCES users(username),
         body VARCHAR NOT NULL,
-        created_at TIMESTAMP DEFAULT NOW(),
+        created_at TIMESTAMPTZ DEFAULT NOW(),
         votes INT DEFAULT 0 NOT NULL,
         article_img_url VARCHAR DEFAULT 'https://images.pexels.com/photos/97050/pexels-photo-97050.jpeg?w=700&h=700'
       );`);
@@ -55,7 +55,7 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
         article_id INT REFERENCES articles(article_id) NOT NULL,
         author VARCHAR REFERENCES users(username) NOT NULL,
         votes INT DEFAULT 0 NOT NULL,
-        created_at TIMESTAMP DEFAULT NOW()
+        created_at TIMESTAMPTZ DEFAULT NOW()
       );`);
     })
     .then(() => {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,5 +1,4 @@
 const db = require("../db/connection");
-const { fixTimestamp } = require("./utils");
 
 exports.selectArticles = ({
     sorted_by = "created_at",
@@ -35,7 +34,7 @@ exports.selectArticles = ({
             desc: "Order must be 'asc' or 'desc'",
         });
     }
-    
+
     const valueArray = [];
     const queryArray = [];
 
@@ -61,10 +60,6 @@ exports.selectArticles = ({
     `;
 
     return db.query(query, valueArray).then(({ rows }) => {
-        rows.forEach((article) => {
-            article.created_at = fixTimestamp(article.created_at);
-        });
-
         return rows;
     });
 };
@@ -89,9 +84,7 @@ exports.selectArticleById = (article_id) => {
             });
         }
 
-        const article = rows[0];
-        article.created_at = fixTimestamp(article.created_at);
-        return article;
+        return rows[0];
     });
 };
 
@@ -111,8 +104,6 @@ exports.updateArticleVotes = (articleId, votes) => {
                 desc: "No article found with given ID",
             });
         }
-
-        rows[0].created_at = fixTimestamp(rows[0].created_at);
 
         return rows[0];
     });

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,5 +1,4 @@
 const db = require("../db/connection");
-const { fixTimestamp } = require("./utils");
 
 exports.selectCommentByCommentId = (commentId) => {
     const query = `
@@ -28,10 +27,6 @@ exports.selectCommentsByArticleId = (articleId) => {
     `;
 
     return db.query(query, [articleId]).then(({ rows }) => {
-        rows.forEach((comment) => {
-            comment.created_at = fixTimestamp(comment.created_at);
-        });
-
         return rows;
     });
 };
@@ -66,8 +61,6 @@ exports.updateCommentVotes = (commentId, inc_votes) => {
                 desc: "No comment found with given ID",
             });
         }
-
-        rows[0].created_at = fixTimestamp(rows[0].created_at);
 
         return rows[0];
     });

--- a/models/utils.js
+++ b/models/utils.js
@@ -1,8 +1,0 @@
-exports.fixTimestamp = (date) => {
-    // For some reason, Postgres seems to be returning the date with a
-    // timezone I didn't ask for, so I need to account for the discrepency.
-    // The worst part is, not every date is affected by this.
-    const offsetMilliseconds = date.getTimezoneOffset() * 60 * 1000;
-    const correctTimestamp = Date.parse(date) - offsetMilliseconds;
-    return new Date(correctTimestamp);
-};


### PR DESCRIPTION
PostgreSQL returns timestamp values in the format: `2020-07-09 21:11:00`.

By default, this is given to `Date()` and then returned.

JavaScript, in it's limitless wisdom, decided that that exact format will be the only one to be interpreted as local time (which I suppose is fair given ISO 8601). What this means is that if the date happens to be during Daylight Savings Time, JS will try to 'correct' the timestamp to represent what it thinks it the actual UTC time. Think of this as implicitly appending `+01` to the string assuming BST.

In the end, the solution was to use `TIMESTAMPTZ` when creating the tables. This formats the resulting string in the format: `2020-07-09 22:11:00+01`, which JS happily turns into the correct UTC timestamp.