### PR TITLE
Implement limit and p queires for `GET /api/articles` and initial tests

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -352,6 +352,70 @@ describe("/api/articles", () => {
                     });
             });
         });
+
+        describe("?limit=", () => {
+            test("200: returns amount of articles specified in limit query", () => {
+                return request(app)
+                    .get("/api/articles?limit=5")
+                    .expect(200)
+                    .then(({ body: { articles, total_count } }) => {
+                        expect(articles).toHaveLength(5);
+                        expect(total_count).toBe(13);
+                    });
+            });
+
+            test("200: returns 10 articles if limit query not specified", () => {
+                return request(app)
+                    .get("/api/articles?limit=")
+                    .expect(200)
+                    .then(({ body: { articles, total_count } }) => {
+                        expect(articles).toHaveLength(10);
+                        expect(total_count).toBe(13);
+                    });
+            });
+
+            test("200: returns all articles if limit larger than number of articles", () => {
+                return request(app)
+                    .get("/api/articles?limit=100")
+                    .expect(200)
+                    .then(({ body: { articles, total_count } }) => {
+                        expect(articles).toHaveLength(13);
+                        expect(total_count).toBe(13);
+                    });
+            });
+
+            test("400: returns error if limit is set to 0", () => {
+                return request(app)
+                    .get("/api/articles?limit=0")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Cannot serve fewer than 1 article");
+                    });
+            });
+
+            test("400: returns error if limit is set to a negative number", () => {
+                return request(app)
+                    .get("/api/articles?limit=-5")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Cannot serve fewer than 1 article");
+                    });
+            });
+
+            test('400: returns error if limit is not a number', () => {
+                return request(app)
+                .get("/api/articles?limit=a")
+                .expect(400)
+                .then(({ body: {msg, desc}}) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Limit must be a number");
+                })
+            });
+        });
+
+        describe("?p=", () => {});
     });
 
     describe("POST", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -404,18 +404,108 @@ describe("/api/articles", () => {
                     });
             });
 
-            test('400: returns error if limit is not a number', () => {
+            test("400: returns error if limit is not a number", () => {
                 return request(app)
-                .get("/api/articles?limit=a")
-                .expect(400)
-                .then(({ body: {msg, desc}}) => {
+                    .get("/api/articles?limit=a")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
                         expect(msg).toBe("Bad request");
                         expect(desc).toBe("Limit must be a number");
-                })
+                    });
             });
         });
 
-        describe("?p=", () => {});
+        describe("?p=", () => {
+            test("200: returns first page of articles", () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=1")
+                    .expect(200)
+                    .then(({ body: { articles, total_count } }) => {
+                        expect(articles).toHaveLength(5);
+                        expect(total_count).toBe(13);
+                    });
+            });
+
+            test("200: returns second page of articles", () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=2")
+                    .expect(200)
+                    .then(({ body: { articles, total_count } }) => {
+                        expect(articles).toHaveLength(5);
+                        expect(total_count).toBe(13);
+                    });
+            });
+
+            test("200: returns last page of articles", () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=3")
+                    .expect(200)
+                    .then(({ body: { articles, total_count } }) => {
+                        expect(articles).toHaveLength(3);
+                        expect(total_count).toBe(13);
+                    });
+            });
+
+            test("400: returns error if page contains no articles", () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=4")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Cannot serve requested page");
+                    });
+            });
+
+            test('400: returns error if page is set to 0', () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=0")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Cannot serve requested page");
+                    });
+            });
+
+            test('400: returns error if page set below 0', () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=-1")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Cannot serve requested page");
+                    });
+            });
+
+            test('400: returns error if page is not a number', () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=a")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Page must be a number");
+                    });
+            });
+
+            test('400: returns error if page query not specified', () => {
+                return request(app)
+                    .get("/api/articles?limit=5&p=")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Page must be a number");
+                    });
+            });
+
+            test('400: returns error if page query used without limit', () => {
+                return request(app)
+                    .get("/api/articles?p=2")
+                    .expect(400)
+                    .then(({ body: { msg, desc } }) => {
+                        expect(msg).toBe("Bad request");
+                        expect(desc).toBe("Cannot serve page without limit");
+                    });
+            });
+        });
     });
 
     describe("POST", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -421,6 +421,7 @@ describe("/api/articles", () => {
                     .get("/api/articles?limit=5&p=1")
                     .expect(200)
                     .then(({ body: { articles, total_count } }) => {
+                        expect(articles[0].article_id).toBe(3);
                         expect(articles).toHaveLength(5);
                         expect(total_count).toBe(13);
                     });
@@ -431,6 +432,7 @@ describe("/api/articles", () => {
                     .get("/api/articles?limit=5&p=2")
                     .expect(200)
                     .then(({ body: { articles, total_count } }) => {
+                        expect(articles[0].article_id).toBe(5);
                         expect(articles).toHaveLength(5);
                         expect(total_count).toBe(13);
                     });
@@ -441,6 +443,7 @@ describe("/api/articles", () => {
                     .get("/api/articles?limit=5&p=3")
                     .expect(200)
                     .then(({ body: { articles, total_count } }) => {
+                        expect(articles[0].article_id).toBe(8);
                         expect(articles).toHaveLength(3);
                         expect(total_count).toBe(13);
                     });

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -20,7 +20,7 @@ exports.getArticles = (req, res, next) => {
             return outcomes[outcomes.length - 1];
         })
         .then((articles) => {
-            res.status(200).send({ articles });
+            res.status(200).send(articles);
         })
         .catch(next);
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,7 +11,7 @@
     },
     "GET /api/articles": {
         "description": "serves an array of all articles, can be filtered with queries",
-        "queries": ["topic", "sorted_by", "order"],
+        "queries": ["topic", "sorted_by", "order", "limit", "p"],
         "exampleResponse": {
             "articles": [
                 {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -3,6 +3,7 @@ const db = require("../db/connection");
 exports.selectArticles = ({
     sorted_by = "created_at",
     order = "desc",
+    limit,
     ...queryObj
 }) => {
     const validSorts = [
@@ -49,18 +50,41 @@ exports.selectArticles = ({
     }
 
     const query = `
-        SELECT a.author, a.title, a.article_id, a.topic,
-        a.created_at, a.votes, a.article_img_url,
-        CAST(COUNT(c.article_id) AS INTEGER) AS comment_count
-        FROM articles AS a
-        LEFT JOIN comments AS c ON a.article_id = c.article_id
-        ${whereClause}
-        GROUP BY a.article_id
-        ORDER BY ${sorted_by} ${order};
+    SELECT a.author, a.title, a.article_id, a.topic,
+    a.created_at, a.votes, a.article_img_url,
+    CAST(COUNT(c.article_id) AS INTEGER) AS comment_count
+    FROM articles AS a
+    LEFT JOIN comments AS c ON a.article_id = c.article_id
+    ${whereClause}
+    GROUP BY a.article_id
+    ORDER BY ${sorted_by} ${order};
     `;
 
     return db.query(query, valueArray).then(({ rows }) => {
-        return rows;
+        if (limit === undefined) {
+            return { articles: rows };
+        } else if (limit === "") {
+            limit = 10;
+        }
+
+        if (isNaN(Number(limit))) {
+            return Promise.reject({
+                status: 400,
+                msg: "Bad request",
+                desc: "Limit must be a number",
+            });
+        } else if (Number(limit) <= 0) {
+            return Promise.reject({
+                status: 400,
+                msg: "Bad request",
+                desc: "Cannot serve fewer than 1 article",
+            });
+        }
+
+        return {
+            articles: rows.slice(0, Number(limit)),
+            total_count: rows.length,
+        };
     });
 };
 


### PR DESCRIPTION
Some tests are still missing, especially those which combine multiple queries.